### PR TITLE
Adding the ability to include a dashboard button in a notify message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 orb.yml
+.idea

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
+| `dashboard_link` | `string` |  | Optional dashboard link property for the [Slack message attachment] |
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Publishes and releases the version of the Orb to the CCI repo. Reads in Semantic version for the arg.
+# You must have a valid CCI token setup to run this script.
+
+if [ $# -eq 0 ]
+  then
+    echo "The semantic version must be provided as an argument. I.E. '1.0.0'"
+else
+  circleci config pack src > orb.yml
+  circleci orb validate orb.yml
+  circleci orb publish orb.yml "narrativescience/slack@$1"
+fi
+

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -67,6 +67,16 @@ parameters:
     type: boolean
     default: true
 
+  include_dashboard:
+    description: Include a dashboard link button
+    type: boolean
+    default: false
+
+  dashboard_link:
+    description: The URL to the dashboard
+    type: string
+    default: ""
+
 steps:
   - run:
       name: Provide error if non-bash shell
@@ -142,8 +152,15 @@ steps:
                       \"type\": \"button\", \
                       \"text\": \"Visit Job\", \
                       \"url\": \"$CIRCLE_BUILD_URL\" \
-                    } \
+                    }, \
                     <</ parameters.include_visit_job_action >>
+                    <<# parameters.include_dashboard >>
+                    { \
+                      \"type\": \"button\", \
+                      \"text\": \"Dashboard\", \
+                      \"url\": \"<< parameters.dashboard_link >>\" \
+                    } \
+                    <</ parameters.include_dashboard >>
                   ], \
                   \"color\": \"<< parameters.color >>\" \
                 } \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -67,11 +67,6 @@ parameters:
     type: boolean
     default: true
 
-  include_dashboard:
-    description: Include a dashboard link button
-    type: boolean
-    default: false
-
   dashboard_link:
     description: The URL to the dashboard
     type: string
@@ -154,13 +149,13 @@ steps:
                       \"url\": \"$CIRCLE_BUILD_URL\" \
                     }, \
                     <</ parameters.include_visit_job_action >>
-                    <<# parameters.include_dashboard >>
+                    <<# parameters.dashboard_link >>
                     { \
                       \"type\": \"button\", \
                       \"text\": \"Dashboard\", \
                       \"url\": \"<< parameters.dashboard_link >>\" \
                     } \
-                    <</ parameters.include_dashboard >>
+                    <</ parameters.dashboard_link >>
                   ], \
                   \"color\": \"<< parameters.color >>\" \
                 } \


### PR DESCRIPTION
# Overview: 
Adding the ability to include a dashboard button in a notify message

### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Wanted to display a link to some test result dashboards

### Description

Added the action to the notify command. This comes with a new optional param that can be passed into the notify command.
