### PR TITLE
Lighthouse buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Notify a slack channel with a custom message at any point in a job with this cus
 | `include_project_field` | `boolean` | `true` | Whether or not to include the _Project_ field in the message |
 | `include_job_number_field` | `boolean` | `true` | Whether or not to include the _Job Number_ field in the message |
 | `include_visit_job_action` | `boolean` | `true` | Whether or not to include the _Visit Job_ action in the message |
-| `button_links` | `string` |  | Optional dashboard link property for the [Slack message attachment] (space delimited))|
+| `button_links` | `string` |  | Optional dashboard link property for the [Slack message attachment] (space delimited)|
 
 [Slack message attachment]: https://api.slack.com/docs/message-attachments
 

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,25 +87,18 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        AUTHOR_NAME="<< parameters.author_name >>"
-        AUTHOR_LINK="<< parameters.author_link >>"
-        TITLE="<< parameters.title >>"
-        TITLE_LINK="<< parameters.title_link >>"
-        FOOTER="<< parameters.footer >>"
-        TS="<< parameters.ts >>"
-        COLOR="<< parameters.color >>"
         attachments_json="[{
           \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
-          \"author_name\": \"$AUTHOR_NAME\",
-          \"author_link\": \"$AUTHOR_LINK\",
-          \"title\": \"$TITLE\",
-          \"title_link\": \"$TITLE_LINK\",
-          \"footer\": \"$FOOTER\",
-          \"ts\": \"$TS\",
+          \"author_name\": \"<< parameters.author_name >>\",
+          \"author_link\": \"<< parameters.author_link >>\",
+          \"title\": \"<< parameters.title >>\",
+          \"title_link\": \"<< parameters.title_link >>"\",
+          \"footer\": \"<< parameters.footer >>\",
+          \"ts\": \"<< parameters.ts >>\",
           \"fields\": [],
           \"actions\": [],
-          \"color\": \"$COLOR\"
+          \"color\": \"<< parameters.color >>\"
         }]"
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,44 +87,42 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        attachments_json="[ \
-        { \
-          \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \
-          \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
-          \"author_name\": \"<< parameters.author_name >>\", \
-          \"author_link\": \"<< parameters.author_link >>\", \
-          \"title\": \"<< parameters.title >>\", \
-          \"title_link\": \"<< parameters.title_link >>\", \
-          \"footer\": \"<< parameters.footer >>\", \
-          \"ts\": \"<< parameters.ts >>\", \
-          \"fields\": [], \
-          \"actions\": [], \
-          \"color\": \"<< parameters.color >>\" \
-        } \
-        ] "
+        attachments_json="[{
+          \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\",
+          \"text\": \"<< parameters.message >> $SLACK_MENTIONS\",
+          \"author_name\": \"<< parameters.author_name >>\",
+          \"author_link\": \"<< parameters.author_link >>\",
+          \"title\": \"<< parameters.title >>\",
+          \"title_link\": \"<< parameters.title_link >>"\",
+          \"footer\": \"<< parameters.footer >>\",
+          \"ts\": \"<< parameters.ts >>\",
+          \"fields\": [],
+          \"actions\": [],
+          \"color\": \"<< parameters.color >>\"
+        }]"
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
-        { \
-          \"title\": \"Project\", \
-          \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
-          \"short\": true \
-        } \")
+        {
+          \"title\": \"Project\",
+          \"value\": \"$CIRCLE_PROJECT_REPONAME\",
+          \"short\": true
+        }")
         <</ parameters.include_project_field >>
         <<# parameters.include_job_number_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
-        { \
-          \"title\": \"Job Number\", \
-          \"value\": \"$CIRCLE_BUILD_NUM\", \
-          \"short\": true \
-        } \")
+        {
+          \"title\": \"Job Number\",
+          \"value\": \"$CIRCLE_BUILD_NUM\",
+          \"short\": true
+        }")
         <</ parameters.include_job_number_field >>
         <<# parameters.include_visit_job_action >>
         attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
-        { \
-          \"type\": \"button\", \
-          \"text\": \"Visit Job\", \
-          \"url\": \"$CIRCLE_BUILD_URL\" \
-        } \")
+        {
+          \"type\": \"button\",
+          \"text\": \"Visit Job\",
+          \"url\": \"$CIRCLE_BUILD_URL\"
+        }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
         button_links='<< parameters.button_links >>'
@@ -132,14 +130,33 @@ steps:
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
-        	{ \
-              \"type\": \"button\", \
-              \"text\": \"$name\", \
-              \"url\": \"$link\" \
-        	} \")
+        	{
+              \"type\": \"button\",
+              \"text\": \"$name\",
+              \"url\": \"$link\"
+        	}")
         done
         <</ parameters.button_links >>
-        echo "$attachments_json"
+        function rawurlencode {
+          local string="${1}"
+          local strlen=${#string}
+          local encoded=""
+          local pos c o
+
+          for (( pos=0 ; pos<strlen ; pos++ )); do
+             c=${string:${pos}:1}
+             case "$c" in
+                [-_.~a-zA-Z0-9] ) o="${c}" ;;
+                * )               printf -v o '%%%02x' "'$c"
+             esac
+             encoded+="${o}"
+          done
+          echo "${encoded}"    # You can either set a return variable (FASTER)
+          REPLY="${encoded}"   #+or echo the result (EASIER)... or both... :p
+        }
+        encoded_attachments_json=$(rawurlencode "$attachments_json")
+        echo $attachments_json
+        echo $encoded_attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"
@@ -170,7 +187,7 @@ steps:
             <<# parameters.channel >>
             -d "channel=<< parameters.channel >>"
             <</ parameters.channel >>
-            -d "attachments=[$attachments_json]"
+            -d "attachments=[$encoded_attachments_json]"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -134,8 +134,7 @@ steps:
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
         button_links='<< parameters.button_links >>'
-        for link in '<< parameters.button_links >>'; do
-        $button_links
+        for link in $button_links; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -67,7 +67,7 @@ parameters:
     type: boolean
     default: true
 
-  lighthouse_button_links:
+  test_results_button_links:
     description: A string (json formatted) with the test names and results links
     type: string
     default: ""
@@ -132,7 +132,7 @@ steps:
         	"url": "<< parameters.dashboard_link >>"
         }')
         <</ parameters.dashboard_link >>
-        <<# parameters.lighthouse_button_links >>
+        <<# parameters.test_results_button_links >>
         for link in << parameters.lighthouse_ph_results_link >>; do
         	name="${link##*/}"
         	name="${name%*.html}"
@@ -143,7 +143,7 @@ steps:
         		"url": "'"$link"'"
         	}')
         done
-        <</ parameters.lighthouse_button_links >>
+        <</ parameters.test_results_button_links >>
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,6 +133,20 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
+
+        IFS=' ' # space is set as delimiter
+        read -ra button_links <<< "<< parameters.button_links >>"
+        for link in "${button_links[@]}"; do
+            name="${link##*/}"
+                name="${name%*.html}"
+                attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
+                {
+                  \"type\": \"button\",
+                  \"text\": \"$name\",
+                  \"url\": \"$link\"
+                }")
+        done
+
         for link in '<< parameters.button_links >>'; do
         	name="${link##*/}"
         	name="${name%*.html}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -93,7 +93,7 @@ steps:
           \"author_name\": \"<< parameters.author_name >>\",
           \"author_link\": \"<< parameters.author_link >>\",
           \"title\": \"<< parameters.title >>\",
-          \"title_link\": \"<< parameters.title_link >>"\",
+          \"title_link\": \"<< parameters.title_link >>\",
           \"footer\": \"<< parameters.footer >>\",
           \"ts\": \"<< parameters.ts >>\",
           \"fields\": [],

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -150,9 +150,8 @@ steps:
           \"url\": \"$CIRCLE_BUILD_URL\"
         }")
         <</ parameters.include_visit_job_action >>
-        echo << parameters.button_links >>
         <<# parameters.button_links >>
-        for link in \"<< parameters.button_links >>\"; do
+        for link in << parameters.button_links >>; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -179,4 +179,8 @@ steps:
             -d "attachments=[$attachments_json]"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
+        echo "******************"
+        echo "******************"
+        echo "******************"
+        echo "******************"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -144,6 +144,7 @@ steps:
         	}')
         done
         <</ parameters.button_links >>
+        print(attachments_json)
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -88,40 +88,40 @@ steps:
       command: |
         # set up attachments json
         attachments_json="[{
-          \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\",
-          \"text\": \"<< parameters.message >> $SLACK_MENTIONS\",
-          \"author_name\": \"<< parameters.author_name >>\",
-          \"author_link\": \"<< parameters.author_link >>\",
-          \"title\": \"<< parameters.title >>\",
-          \"title_link\": \"<< parameters.title_link >>"\",
-          \"footer\": \"<< parameters.footer >>\",
-          \"ts\": \"<< parameters.ts >>\",
-          \"fields\": [],
-          \"actions\": [],
-          \"color\": \"<< parameters.color >>\"
+          \\"fallback\\": \\"<< parameters.message >> - $CIRCLE_BUILD_URL\\",
+          \\"text\\": \\"<< parameters.message >> $SLACK_MENTIONS\\",
+          \\"author_name\\": \\"<< parameters.author_name >>\\",
+          \\"author_link\\": \\"<< parameters.author_link >>\\",
+          \\"title\\": \\"<< parameters.title >>\\",
+          \\"title_link\\": \\"<< parameters.title_link >>"\\",
+          \\"footer\\": \\"<< parameters.footer >>\\",
+          \\"ts\\": \\"<< parameters.ts >>\\",
+          \\"fields\\": [],
+          \\"actions\\": [],
+          \\"color\\": \\"<< parameters.color >>\\"
         }]"
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         {
-          \"title\": \"Project\",
-          \"value\": \"$CIRCLE_PROJECT_REPONAME\",
-          \"short\": true
+          \\"title\\": \\"Project\\",
+          \\"value\\": \\"$CIRCLE_PROJECT_REPONAME\\",
+          \\"short\\": true
         }")
         <</ parameters.include_project_field >>
         <<# parameters.include_job_number_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         {
-          \"title\": \"Job Number\",
-          \"value\": \"$CIRCLE_BUILD_NUM\",
-          \"short\": true
+          \\"title\\": \\"Job Number\\",
+          \\"value\": \\"$CIRCLE_BUILD_NUM\\",
+          \\"short\\": true
         }")
         <</ parameters.include_job_number_field >>
         <<# parameters.include_visit_job_action >>
         attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
         {
-          \"type\": \"button\",
-          \"text\": \"Visit Job\",
-          \"url\": \"$CIRCLE_BUILD_URL\"
+          \\"type\\": \\"button\\",
+          \\"text\\": \\"Visit Job\\",
+          \\"url\\": \\"$CIRCLE_BUILD_URL\\"
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
@@ -131,13 +131,13 @@ steps:
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
         	{
-              \"type\": \"button\",
-              \"text\": \"$name\",
-              \"url\": \"$link\"
+              \\"type\\": \\"button\\",
+              \\"text\\": \\"$name\\",
+              \\"url\\": \\"$link\\"
         	}")
         done
         <</ parameters.button_links >>
-        echo $attachments_json
+        echo "$attachments_json"
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -136,7 +136,7 @@ steps:
         	}')
         done
         <</ parameters.button_links >>
-        print(attachments_json)
+        echo $attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -163,6 +163,7 @@ steps:
         	}")
         done
         <</ parameters.button_links >>
+        echo $attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        for link in << parameters.button_links >>; do
+        for link in "<< parameters.button_links >>"; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,42 +87,44 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        attachments_json="[{
-          \\"fallback\\": \\"<< parameters.message >> - $CIRCLE_BUILD_URL\\",
-          \\"text\\": \\"<< parameters.message >> $SLACK_MENTIONS\\",
-          \\"author_name\\": \\"<< parameters.author_name >>\\",
-          \\"author_link\\": \\"<< parameters.author_link >>\\",
-          \\"title\\": \\"<< parameters.title >>\\",
-          \\"title_link\\": \\"<< parameters.title_link >>"\\",
-          \\"footer\\": \\"<< parameters.footer >>\\",
-          \\"ts\\": \\"<< parameters.ts >>\\",
-          \\"fields\\": [],
-          \\"actions\\": [],
-          \\"color\\": \\"<< parameters.color >>\\"
-        }]"
+        attachments_json="[ \
+        { \
+          \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \
+          \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
+          \"author_name\": \"<< parameters.author_name >>\", \
+          \"author_link\": \"<< parameters.author_link >>\", \
+          \"title\": \"<< parameters.title >>\", \
+          \"title_link\": \"<< parameters.title_link >>"\", \
+          \"footer\": \"<< parameters.footer >>\", \
+          \"ts\": \"<< parameters.ts >>\", \
+          \"fields\": [], \
+          \"actions\": [], \
+          \"color\": \"<< parameters.color >>\" \
+        } \
+        ] \"
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
-        {
-          \\"title\\": \\"Project\\",
-          \\"value\\": \\"$CIRCLE_PROJECT_REPONAME\\",
-          \\"short\\": true
-        }")
+        { \
+          \"title\": \"Project\", \
+          \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+          \"short\": true \
+        } \")
         <</ parameters.include_project_field >>
         <<# parameters.include_job_number_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
-        {
-          \\"title\\": \\"Job Number\\",
-          \\"value\": \\"$CIRCLE_BUILD_NUM\\",
-          \\"short\\": true
-        }")
+        { \
+          \"title\": \"Job Number\", \
+          \"value\": \"$CIRCLE_BUILD_NUM\", \
+          \"short\": true \
+        } \")
         <</ parameters.include_job_number_field >>
         <<# parameters.include_visit_job_action >>
         attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
-        {
-          \\"type\\": \\"button\\",
-          \\"text\\": \\"Visit Job\\",
-          \\"url\\": \\"$CIRCLE_BUILD_URL\\"
-        }")
+        { \
+          \"type\": \"button\", \
+          \"text\": \"Visit Job\", \
+          \"url\": \"$CIRCLE_BUILD_URL\" \
+        } \")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
         button_links='<< parameters.button_links >>'
@@ -130,11 +132,11 @@ steps:
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
-        	{
-              \\"type\\": \\"button\\",
-              \\"text\\": \\"$name\\",
-              \\"url\\": \\"$link\\"
-        	}")
+        	{ \
+              \"type\": \"button\", \
+              \"text\": \"$name\", \
+              \"url\": \"$link\" \
+        	} \")
         done
         <</ parameters.button_links >>
         echo "$attachments_json"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,14 +87,14 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE=\"<< parameters.message >>\"
-        AUTHOR_NAME=\"<< parameters.author_name >>\"
-        AUTHOR_LINK=\"<< parameters.author_link >>\"
-        TITLE=\"<< parameters.title >>\"
-        TITLE_LINK=\"<< parameters.title_link >>\"
-        FOOTER=\"<< parameters.footer >>\"
-        TS=\"<< parameters.ts >>\"
-        COLOR=\"<< parameters.color >>\"
+        MESSAGE="\"<< parameters.message >>\""
+        AUTHOR_NAME="\"<< parameters.author_name >>\""
+        AUTHOR_LINK="\"<< parameters.author_link >>\""
+        TITLE="\"<< parameters.title >>\""
+        TITLE_LINK="\"<< parameters.title_link >>\""
+        FOOTER="\"<< parameters.footer >>\""
+        TS="\"<< parameters.ts >>\""
+        COLOR="\"<< parameters.color >>\""
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        BUTTON_LINKS=\"<< parameters.button_links >>\"
+        BUTTON_LINKS="\"<< parameters.button_links >>\""
         for link in $BUTTON_LINKS; do
         	name="${link##*/}"
         	name="${name%*.html}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -150,6 +150,7 @@ steps:
           \"url\": \"$CIRCLE_BUILD_URL\"
         }")
         <</ parameters.include_visit_job_action >>
+        echo << parameters.button_links >>
         <<# parameters.button_links >>
         for link in \"<< parameters.button_links >>\"; do
         	name="${link##*/}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -25,12 +25,12 @@ parameters:
   author_name:
     description: Optional author name
     type: string
-    default: ""
+    default: "asdf"
 
   author_link:
     description: Optional author link
     type: string
-    default: ""
+    default: "asdf"
 
   title:
     description: Optional title
@@ -45,12 +45,12 @@ parameters:
   footer:
     description: Optional footer
     type: string
-    default: ""
+    default: "asdf"
 
   ts:
     description: Optional timestamp
     type: string
-    default: ""
+    default: "asdf"
 
   include_project_field:
     description: Whether or not to include the Project field in the message
@@ -108,18 +108,18 @@ steps:
           \"author_link\": \"<< parameters.author_link >>\"
          }")
         <</ parameters.author_link >>
-        <<# parameters.parameters.ts >>
+        <<# parameters.ts >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
           \"ts\": \"<< parameters.ts >>\"
         }")
-        <</ parameters.parameters.ts >>
-        <<# parameters.parameters.footer >>
+        <</ parameters.ts >>
+        <<# parameters.footer >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
           \"footer\": \"<< parameters.footer >>\"
         }")
-        <</ parameters.parameters.footer >>
+        <</ parameters.footer >>
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         {

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -98,12 +98,12 @@ steps:
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
-          \"author_name\": \"$AUTHOR_NAME\",
-          \"author_link\": \"$AUTHOR_LINK\",
+#          \"author_name\": \"$AUTHOR_NAME\",
+#          \"author_link\": \"$AUTHOR_LINK\",
           \"title\": \"$TITLE\",
-          \"title_link\": \"$TITLE_LINK\",
-          \"footer\": \"$FOOTER\",
-          \"ts\": \"$TS\",
+#          \"title_link\": \"$TITLE_LINK\",
+#          \"footer\": \"$FOOTER\",
+#          \"ts\": \"$TS\",
           \"fields\": [],
           \"actions\": [],
           \"color\": \"$COLOR\"
@@ -179,8 +179,4 @@ steps:
             -d "attachments=[$attachments_json]"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
-        echo "******************"
-        echo "******************"
-        echo "******************"
-        echo "******************"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,14 +87,14 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE=<< parameters.message >>
-        AUTHOR_NAME=<< parameters.author_name >>
-        AUTHOR_LINK=<< parameters.author_link >>
-        TITLE=<< parameters.title >>
-        TITLE_LINK=<< parameters.title_link >>
-        FOOTER=<< parameters.footer >>
-        TS=<< parameters.ts >>
-        COLOR=<< parameters.color >>
+        MESSAGE="<< parameters.message >>"
+        AUTHOR_NAME="<< parameters.author_name >>"
+        AUTHOR_LINK=<"< parameters.author_link >>"
+        TITLE="<< parameters.title >>"
+        TITLE_LINK="<< parameters.title_link >>"
+        FOOTER="<< parameters.footer >>"
+        TS="<< parameters.ts >>"
+        COLOR="<"< parameters.color >>"
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        BUTTON_LINKS=<< parameters.button_links >>
+        BUTTON_LINKS="<< parameters.button_links >>"
         for link in $BUTTON_LINKS; do
         	name="${link##*/}"
         	name="${name%*.html}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -25,12 +25,12 @@ parameters:
   author_name:
     description: Optional author name
     type: string
-    default: "asdf"
+    default: ""
 
   author_link:
     description: Optional author link
     type: string
-    default: "asdf"
+    default: ""
 
   title:
     description: Optional title
@@ -45,12 +45,12 @@ parameters:
   footer:
     description: Optional footer
     type: string
-    default: "footer"
+    default: ""
 
   ts:
     description: Optional timestamp
     type: string
-    default: "ts"
+    default: ""
 
   include_project_field:
     description: Whether or not to include the Project field in the message
@@ -157,7 +157,6 @@ steps:
         	}")
         done
         <</ parameters.button_links >>
-        echo $attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -67,7 +67,7 @@ parameters:
     type: boolean
     default: true
 
-  test_results_button_links:
+  button_links:
     description: A string (json formatted) with the test names and results links
     type: string
     default: ""
@@ -89,16 +89,16 @@ steps:
         # set up attachments json
         attachments_json='[{
         	"fallback": "<< parameters.message >> - $CIRCLE_BUILD_URL",
-            "text": "<< parameters.message >> $SLACK_MENTIONS",
-            "author_name": "<< parameters.author_name >>",
-            "author_link":"<< parameters.author_link >>",
-            "title": "<< parameters.title >>",
-            "title_link": "<< parameters.title_link >>",
-            "footer": "<< parameters.footer >>",
-            "ts": "<< parameters.ts >>",
-            "fields": [],
-            "actions": [],
-            "color": "<< parameters.color >>"
+          "text": "<< parameters.message >> $SLACK_MENTIONS",
+          "author_name": "<< parameters.author_name >>",
+          "author_link":"<< parameters.author_link >>",
+          "title": "<< parameters.title >>",
+          "title_link": "<< parameters.title_link >>",
+          "footer": "<< parameters.footer >>",
+          "ts": "<< parameters.ts >>",
+          "fields": [],
+          "actions": [],
+          "color": "<< parameters.color >>"
         }]'
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
@@ -132,7 +132,7 @@ steps:
         	"url": "<< parameters.dashboard_link >>"
         }')
         <</ parameters.dashboard_link >>
-        <<# parameters.test_results_button_links >>
+        <<# parameters.button_links >>
         for link in << parameters.lighthouse_ph_results_link >>; do
         	name="${link##*/}"
         	name="${name%*.html}"
@@ -143,7 +143,7 @@ steps:
         		"url": "'"$link"'"
         	}')
         done
-        <</ parameters.test_results_button_links >>
+        <</ parameters.button_links >>
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,53 +87,62 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        attachments_json='[{
-          "fallback": "<< parameters.message >> - $CIRCLE_BUILD_URL",
-          "text": "<< parameters.message >> $SLACK_MENTIONS",
-          "author_name": "<< parameters.author_name >>",
-          "author_link":"<< parameters.author_link >>",
-          "title": "<< parameters.title >>",
-          "title_link": "<< parameters.title_link >>",
-          "footer": "<< parameters.footer >>",
-          "ts": "<< parameters.ts >>",
-          "fields": [],
-          "actions": [],
-          "color": "<< parameters.color >>"
-        }]'
+        MESSAGE= << parameters.message >>
+        AUTHOR_NAME= << parameters.author_name >>
+        AUTHOR_LINK= << parameters.author_link >>
+        TITLE= << parameters.title >>
+        TITLE_LINK= << parameters.title_link >>
+        FOOTER= << parameters.footer >>
+        TS= << parameters.ts >>
+        COLOR= << parameters.color >>
+        attachments_json="[{
+          \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
+          \"text\": \"$MESSAGE $SLACK_MENTIONS\",
+          \"author_name\": \"$AUTHOR_NAME\",
+          \"author_link\": \"AUTHOR_LINK\",
+          \"title\": \"$TITLE\",
+          \"title_link\": \"$TITLE_LINK\",
+          \"footer\": \"$FOOTER\",
+          \"ts\": \"$TS\",
+          \"fields\": [],
+          \"actions\": [],
+          \"color\": \"$COLOR\"
+        }]"
         <<# parameters.include_project_field >>
-        attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
+        attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         {
-          "title": "Project",
-          "value": "$CIRCLE_PROJECT_REPONAME",
-          "short": true
-        }')
+          \"title\": \"Project\",
+          \"value\": \"$CIRCLE_PROJECT_REPONAME\",
+          \"short\": true
+        }")
         <</ parameters.include_project_field >>
         <<# parameters.include_job_number_field >>
-        attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
+        attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         {
-          "title": "Job Number",
-          "value": "$CIRCLE_BUILD_NUM",
-          "short": true
-        }')
+          \"title\": \"Job Number\",
+          \"value\": \"$CIRCLE_BUILD_NUM\",
+          \"short\": true
+        }")
         <</ parameters.include_job_number_field >>
         <<# parameters.include_visit_job_action >>
-        attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
+        attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
         {
-          "type": "button",
-          "text": "Visit Job",
-          "url": "$CIRCLE_BUILD_URL"
-        }')
+          \"type\": \"button\",
+          \"text\": \"Visit Job\",
+          \"url\": \"$CIRCLE_BUILD_URL\"
+        }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        for link in << parameters.button_links >>; do
+        BUTTON_LINKS=<< parameters.button_links >>
+        for link in $BUTTON_LINKS; do
         	name="${link##*/}"
         	name="${name%*.html}"
-        	attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
+        	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
         	{
-              "type": "button",
-              "text": "'"$name"'",
-              "url": "'"$link"'"
-        	}')
+              \"type\": \"button\",
+              \"text\": \"$name\",
+              \"url\": \"$link\"
+        	}")
         done
         <</ parameters.button_links >>
         echo $attachments_json

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -86,75 +86,64 @@ steps:
       name: Slack Notification
       shell: /bin/bash
       command: |
-        # set up potential lighthouse test results
-        curl_arg_1="            -X POST
-                    -H 'Content-Type: application/x-www-form-urlencoded'
-                    -H 'Cache-Control: no-cache'
-                    -d \"token=\${SLACK_OAUTH_TOKEN}\"
-                    -d 'as_user=true'
-                    <<# parameters.channel >>
-                    -d \"channel=<< parameters.channel >>\"
-                    <</ parameters.channel >>
-                    -d \"attachments=[ \\
-                        { \\
-                          \\\"fallback\\\": \\\"<< parameters.message >> - \$CIRCLE_BUILD_URL\\\", \\
-                          \\\"text\\\": \\\"<< parameters.message >> \$SLACK_MENTIONS\\\", \\
-                          \\\"author_name\\\": \\\"<< parameters.author_name >>\\\", \\
-                          \\\"author_link\\\": \\\"<< parameters.author_link >>\\\", \\
-                          \\\"title\\\": \\\"<< parameters.title >>\\\", \\
-                          \\\"title_link\\\": \\\"<< parameters.title_link >>\\\", \\
-                          \\\"footer\\\": \\\"<< parameters.footer >>\\\", \\
-                          \\\"ts\\\": \\\"<< parameters.ts >>\\\", \\
-                          \\\"fields\\\": [ \\
-                            <<# parameters.include_project_field >>
-                            { \\
-                              \\\"title\\\": \\\"Project\\\", \\
-                              \\\"value\\\": \\\"\$CIRCLE_PROJECT_REPONAME\\\", \\
-                              \\\"short\\\": true \\
-                            }, \\
-                            <</ parameters.include_project_field >>
-                            <<# parameters.include_job_number_field >>
-                            { \\
-                              \\\"title\\\": \\\"Job Number\\\", \\
-                              \\\"value\\\": \\\"\$CIRCLE_BUILD_NUM\\\", \\
-                              \\\"short\\\": true \\
-                            } \\
-                            <</ parameters.include_job_number_field >>
-                          ], \\
-                          \\\"actions\\\": [ \\
-                            <<# parameters.include_visit_job_action >>
-                            { \\
-                              \\\"type\\\": \\\"button\\\", \\
-                              \\\"text\\\": \\\"Visit Job\\\", \\
-                              \\\"url\\\": \\\"\$CIRCLE_BUILD_URL\\\" \\
-                            }, \\
-                            <</ parameters.include_visit_job_action >>
-                            <</ parameters.dashboard_link >>
-                            { \\
-                              \\\"type\\\": \\\"button\\\", \\
-                              \\\"text\\\": \\\"Dashboard\\\", \\
-                              \\\"url\\\": \\\"<< parameters.dashboard_link >>\\\" \\
-                            }, \\
-                            <</ parameters.dashboard_link >>
-                            <<# parameters.lighthouse_button_links >>
-                            "
-        for row in $(echo "<< parameters.lighthouse_button_links >>" | jq -c '.[]'); do
-            _jq() {
-             echo ${row} | jq -r ${1}
-            }
-        	curl_arg_2="$curlArg2{ \\
-                             \\\"type\\\": \\\"button\\\", \\
-                             \\\"text\\\": \\\"$(_jq '.name')\\\", \\
-                             \\\"url\\\": \\\"$(_jq '.url')\\\" \\
-                            }, \\
-                            "
+        # set up attachments json
+        attachments_json='[{
+        	"fallback": "<< parameters.message >> - $CIRCLE_BUILD_URL",
+            "text": "<< parameters.message >> $SLACK_MENTIONS",
+            "author_name": "<< parameters.author_name >>",
+            "author_link":"<< parameters.author_link >>",
+            "title": "<< parameters.title >>",
+            "title_link": "<< parameters.title_link >>",
+            "footer": "<< parameters.footer >>",
+            "ts": "<< parameters.ts >>",
+            "fields": [],
+            "actions": [],
+            "color": "<< parameters.color >>"
+        }]'
+        <<# parameters.include_project_field >>
+        attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
+        {
+        	"title": "Project",
+        	"value": "$CIRCLE_PROJECT_REPONAME",
+        	"short": true
+        }')
+        <</ parameters.include_project_field >>
+        <<# parameters.include_job_number_field >>
+        attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
+        {
+        	"title": "Job Number",
+        	"value": "$CIRCLE_BUILD_NUM",
+        	"short": true
+        }')
+        <</ parameters.include_job_number_field >>
+        <<# parameters.include_visit_job_action >>
+        attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
+        {
+        	"type": "button",
+        	"text": "Visit Job",
+        	"url": "$CIRCLE_BUILD_URL"
+        }')
+        <</ parameters.include_visit_job_action >>
+        <<# parameters.dashboard_link >>
+        attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
+        {
+        	"type": "button",
+        	"text": "Dashboard",
+        	"url": "<< parameters.dashboard_link >>"
+        }')
+        <</ parameters.dashboard_link >>
+        <<# parameters.lighthouse_button_links >>
+        for link in << parameters.lighthouse_ph_results_link >>; do
+        	name="${link##*/}"
+        	name="${name%*.html}"
+        	attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
+        	{
+        		"type": "button",
+        		"text": "'"$name"'",
+        		"url": "'"$link"'"
+        	}')
         done
-        curl_arg_3="<</ parameters.lighthouse_button_links >>
-                          ], \\
-                          \\\"color\\\": \\\"<< parameters.color >>\\\" \\
-                        } \\
-                      ]\""
-        curl_args=$curl_arg_1$curl_arg_2$curl_arg_3
+        <</ parameters.lighthouse_button_links >>
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"
@@ -176,6 +165,16 @@ steps:
               fi
             done
           fi
-          CURL_ARGS=("$curl_args")
+          CURL_ARGS=(
+            -X POST
+            -H 'Content-Type: application/x-www-form-urlencoded'
+            -H 'Cache-Control: no-cache'
+            -d "token=${SLACK_OAUTH_TOKEN}"
+            -d 'as_user=true'
+            <<# parameters.channel >>
+            -d "channel=<< parameters.channel >>"
+            <</ parameters.channel >>
+            -d "attachments=[$attachments_json]"
+          )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,7 +133,6 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-
         IFS=' ' # space is set as delimiter
         read -ra button_links <<< "<< parameters.button_links >>"
         for link in "${button_links[@]}"; do
@@ -145,17 +144,6 @@ steps:
                   \"text\": \"$name\",
                   \"url\": \"$link\"
                 }")
-        done
-
-        for link in '<< parameters.button_links >>'; do
-        	name="${link##*/}"
-        	name="${name%*.html}"
-        	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
-        	{
-              \"type\": \"button\",
-              \"text\": \"$name\",
-              \"url\": \"$link\"
-        	}")
         done
         <</ parameters.button_links >>
         echo $attachments_json

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,8 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        BUTTON_LINKS="<< parameters.button_links >>"
-        for link in $BUTTON_LINKS; do
+        for link in << parameters.button_links >>; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        for link in "<< parameters.button_links >>"; do
+        for link in '<< parameters.button_links >>'; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,14 +87,14 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE="<< parameters.message >>"
-        AUTHOR_NAME="<< parameters.author_name >>"
-        AUTHOR_LINK=<"< parameters.author_link >>"
-        TITLE="<< parameters.title >>"
-        TITLE_LINK="<< parameters.title_link >>"
-        FOOTER="<< parameters.footer >>"
-        TS="<< parameters.ts >>"
-        COLOR="<"< parameters.color >>"
+        MESSAGE=\"<< parameters.message >>\"
+        AUTHOR_NAME=\"<< parameters.author_name >>\"
+        AUTHOR_LINK=\"<< parameters.author_link >>\"
+        TITLE=\"<< parameters.title >>\"
+        TITLE_LINK=\"<< parameters.title_link >>\"
+        FOOTER=\"<< parameters.footer >>\"
+        TS=\"<< parameters.ts >>\"
+        COLOR=\"<< parameters.color >>\"
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        BUTTON_LINKS="<< parameters.button_links >>"
+        BUTTON_LINKS=\"<< parameters.button_links >>\"
         for link in $BUTTON_LINKS; do
         	name="${link##*/}"
         	name="${name%*.html}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,17 +133,17 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        IFS=' ' # space is set as delimiter
-        read -ra button_links <<< "<< parameters.button_links >>"
-        for link in "${button_links[@]}"; do
-            name="${link##*/}"
-                name="${name%*.html}"
-                attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
-                {
-                  \"type\": \"button\",
-                  \"text\": \"$name\",
-                  \"url\": \"$link\"
-                }")
+        button_links='<< parameters.button_links >>'
+        for link in '<< parameters.button_links >>'; do
+        $button_links
+        	name="${link##*/}"
+        	name="${name%*.html}"
+        	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +
+        	{
+              \"type\": \"button\",
+              \"text\": \"$name\",
+              \"url\": \"$link\"
+        	}")
         done
         <</ parameters.button_links >>
         echo $attachments_json

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -124,14 +124,6 @@ steps:
           "url": "$CIRCLE_BUILD_URL"
         }')
         <</ parameters.include_visit_job_action >>
-        <<# parameters.dashboard_link >>
-        attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
-        {
-          "type": "button",
-          "text": "Dashboard",
-          "url": "<< parameters.dashboard_link >>"
-        }')
-        <</ parameters.dashboard_link >>
         <<# parameters.button_links >>
         for link in << parameters.button_links >>; do
         	name="${link##*/}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,7 +87,6 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE="<< parameters.message >>"
         AUTHOR_NAME="<< parameters.author_name >>"
         AUTHOR_LINK="<< parameters.author_link >>"
         TITLE="<< parameters.title >>"
@@ -96,9 +95,14 @@ steps:
         TS="<< parameters.ts >>"
         COLOR="<< parameters.color >>"
         attachments_json="[{
-          \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
+          \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
+          \"author_name\": \"$AUTHOR_NAME\",
+          \"author_link\": \"$AUTHOR_LINK\",
           \"title\": \"$TITLE\",
+          \"title_link\": \"$TITLE_LINK\",
+          \"footer\": \"$FOOTER\",
+          \"ts\": \"$TS\",
           \"fields\": [],
           \"actions\": [],
           \"color\": \"$COLOR\"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -187,7 +187,7 @@ steps:
             <<# parameters.channel >>
             -d "channel=<< parameters.channel >>"
             <</ parameters.channel >>
-            -d "attachments="$encoded_attachments_json"
+            -d "attachments=$encoded_attachments_json"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -88,48 +88,48 @@ steps:
       command: |
         # set up attachments json
         attachments_json='[{
-        	"fallback": "<< parameters.message >> - $CIRCLE_BUILD_URL",
-            "text": "<< parameters.message >> $SLACK_MENTIONS",
-            "author_name": "<< parameters.author_name >>",
-            "author_link":"<< parameters.author_link >>",
-            "title": "<< parameters.title >>",
-            "title_link": "<< parameters.title_link >>",
-            "footer": "<< parameters.footer >>",
-            "ts": "<< parameters.ts >>",
-            "fields": [],
-            "actions": [],
-            "color": "<< parameters.color >>"
+          "fallback": "<< parameters.message >> - $CIRCLE_BUILD_URL",
+          "text": "<< parameters.message >> $SLACK_MENTIONS",
+          "author_name": "<< parameters.author_name >>",
+          "author_link":"<< parameters.author_link >>",
+          "title": "<< parameters.title >>",
+          "title_link": "<< parameters.title_link >>",
+          "footer": "<< parameters.footer >>",
+          "ts": "<< parameters.ts >>",
+          "fields": [],
+          "actions": [],
+          "color": "<< parameters.color >>"
         }]'
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
         {
-        	"title": "Project",
-        	"value": "$CIRCLE_PROJECT_REPONAME",
-        	"short": true
+          "title": "Project",
+          "value": "$CIRCLE_PROJECT_REPONAME",
+          "short": true
         }')
         <</ parameters.include_project_field >>
         <<# parameters.include_job_number_field >>
         attachments_json=$(echo $attachments_json | jq '.[].fields[.[].fields | length] |= . +
         {
-        	"title": "Job Number",
-        	"value": "$CIRCLE_BUILD_NUM",
-        	"short": true
+          "title": "Job Number",
+          "value": "$CIRCLE_BUILD_NUM",
+          "short": true
         }')
         <</ parameters.include_job_number_field >>
         <<# parameters.include_visit_job_action >>
         attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
         {
-        	"type": "button",
-        	"text": "Visit Job",
-        	"url": "$CIRCLE_BUILD_URL"
+          "type": "button",
+          "text": "Visit Job",
+          "url": "$CIRCLE_BUILD_URL"
         }')
         <</ parameters.include_visit_job_action >>
         <<# parameters.dashboard_link >>
         attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
         {
-        	"type": "button",
-        	"text": "Dashboard",
-        	"url": "<< parameters.dashboard_link >>"
+          "type": "button",
+          "text": "Dashboard",
+          "url": "<< parameters.dashboard_link >>"
         }')
         <</ parameters.dashboard_link >>
         <<# parameters.test_results_button_links >>
@@ -138,9 +138,9 @@ steps:
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +
         	{
-        		"type": "button",
-        		"text": "'"$name"'",
-        		"url": "'"$link"'"
+              "type": "button",
+              "text": "'"$name"'",
+              "url": "'"$link"'"
         	}')
         done
         <</ parameters.test_results_button_links >>

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -187,7 +187,7 @@ steps:
             <<# parameters.channel >>
             -d "channel=<< parameters.channel >>"
             <</ parameters.channel >>
-            -d "attachments=[$encoded_attachments_json]"
+            -d "attachments=["$encoded_attachments_json"]"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -89,7 +89,7 @@ steps:
         # set up attachments json
         attachments_json="[{
           \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\",
-          \"text\": \"$MESSAGE $SLACK_MENTIONS\",
+          \"text\": \"<< parameters.message >> $SLACK_MENTIONS\",
           \"author_name\": \"<< parameters.author_name >>\",
           \"author_link\": \"<< parameters.author_link >>\",
           \"title\": \"<< parameters.title >>\",

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -94,7 +94,7 @@ steps:
           \"author_name\": \"<< parameters.author_name >>\", \
           \"author_link\": \"<< parameters.author_link >>\", \
           \"title\": \"<< parameters.title >>\", \
-          \"title_link\": \"<< parameters.title_link >>"\", \
+          \"title_link\": \"<< parameters.title_link >>\", \
           \"footer\": \"<< parameters.footer >>\", \
           \"ts\": \"<< parameters.ts >>\", \
           \"fields\": [], \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -68,7 +68,7 @@ parameters:
     default: true
 
   button_links:
-    description: A string (space delimited) with the url names and links
+    description: A string (space delimited) with url links
     type: string
     default: ""
 

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -99,25 +99,25 @@ steps:
         <<# parameters.author_name >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
-          \"author_name\": \""<< parameters.author_name >>\"
+          \"author_name\": \"<< parameters.author_name >>\"
         }")
         <</ parameters.author_name >>
         <<# parameters.author_link >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
-          \"author_link\": \""<< parameters.author_link >>\"
+          \"author_link\": \"<< parameters.author_link >>\"
          }")
         <</ parameters.author_link >>
         <<# parameters.parameters.ts >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
-          \"ts\": \""<< parameters.ts >>\"
+          \"ts\": \"<< parameters.ts >>\"
         }")
         <</ parameters.parameters.ts >>
         <<# parameters.parameters.footer >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
-          \"footer\": \""<< parameters.footer >>\"
+          \"footer\": \"<< parameters.footer >>\"
         }")
         <</ parameters.parameters.footer >>
         <<# parameters.include_project_field >>
@@ -157,6 +157,7 @@ steps:
         	}")
         done
         <</ parameters.button_links >>
+        echo $attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,14 +87,14 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE= << parameters.message >>
-        AUTHOR_NAME= << parameters.author_name >>
-        AUTHOR_LINK= << parameters.author_link >>
-        TITLE= << parameters.title >>
-        TITLE_LINK= << parameters.title_link >>
-        FOOTER= << parameters.footer >>
-        TS= << parameters.ts >>
-        COLOR= << parameters.color >>
+        MESSAGE=<< parameters.message >>
+        AUTHOR_NAME=<< parameters.author_name >>
+        AUTHOR_LINK=<< parameters.author_link >>
+        TITLE=<< parameters.title >>
+        TITLE_LINK=<< parameters.title_link >>
+        FOOTER=<< parameters.footer >>
+        TS=<< parameters.ts >>
+        COLOR=<< parameters.color >>
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,19 +87,19 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE=""<< parameters.message >>""
-        AUTHOR_NAME=""<< parameters.author_name >>""
-        AUTHOR_LINK=""<< parameters.author_link >>""
-        TITLE=""<< parameters.title >>""
-        TITLE_LINK=""<< parameters.title_link >>""
-        FOOTER=""<< parameters.footer >>""
-        TS=""<< parameters.ts >>""
-        COLOR=""<< parameters.color >>""
+        MESSAGE="<< parameters.message >>"
+        AUTHOR_NAME="<< parameters.author_name >>"
+        AUTHOR_LINK="<< parameters.author_link >>"
+        TITLE="<< parameters.title >>"
+        TITLE_LINK="<< parameters.title_link >>"
+        FOOTER="<< parameters.footer >>"
+        TS="<< parameters.ts >>"
+        COLOR="<< parameters.color >>"
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
           \"author_name\": \"$AUTHOR_NAME\",
-          \"author_link\": \"AUTHOR_LINK\",
+          \"author_link\": \"$AUTHOR_LINK\",
           \"title\": \"$TITLE\",
           \"title_link\": \"$TITLE_LINK\",
           \"footer\": \"$FOOTER\",
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        BUTTON_LINKS=""<< parameters.button_links >>""
+        BUTTON_LINKS="<< parameters.button_links >>"
         for link in $BUTTON_LINKS; do
         	name="${link##*/}"
         	name="${name%*.html}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -151,8 +151,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        button_links='<< parameters.button_links >>'
-        for link in $button_links; do
+        for link in \"<< parameters.button_links >>\"; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq ".[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -25,12 +25,12 @@ parameters:
   author_name:
     description: Optional author name
     type: string
-    default: ""
+    default: "asdf"
 
   author_link:
     description: Optional author link
     type: string
-    default: ""
+    default: "asdf"
 
   title:
     description: Optional title
@@ -45,12 +45,12 @@ parameters:
   footer:
     description: Optional footer
     type: string
-    default: ""
+    default: "footer"
 
   ts:
     description: Optional timestamp
     type: string
-    default: ""
+    default: "ts"
 
   include_project_field:
     description: Whether or not to include the Project field in the message
@@ -90,16 +90,36 @@ steps:
         attachments_json="[{
           \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\",
           \"text\": \"<< parameters.message >> $SLACK_MENTIONS\",
-          \"author_name\": \"<< parameters.author_name >>\",
-          \"author_link\": \"<< parameters.author_link >>\",
           \"title\": \"<< parameters.title >>\",
           \"title_link\": \"<< parameters.title_link >>\",
-          \"footer\": \"<< parameters.footer >>\",
-          \"ts\": \"<< parameters.ts >>\",
           \"fields\": [],
           \"actions\": [],
           \"color\": \"<< parameters.color >>\"
         }]"
+        <<# parameters.author_name >>
+        attachments_json=$(echo $attachments_json | jq ".[] +=
+        {
+          \"author_name\": \""<< parameters.author_name >>\"
+        }")
+        <</ parameters.author_name >>
+        <<# parameters.author_link >>
+        attachments_json=$(echo $attachments_json | jq ".[] +=
+        {
+          \"author_link\": \""<< parameters.author_link >>\"
+         }")
+        <</ parameters.author_link >>
+        <<# parameters.parameters.ts >>
+        attachments_json=$(echo $attachments_json | jq ".[] +=
+        {
+          \"ts\": \""<< parameters.ts >>\"
+        }")
+        <</ parameters.parameters.ts >>
+        <<# parameters.parameters.footer >>
+        attachments_json=$(echo $attachments_json | jq ".[] +=
+        {
+          \"footer\": \""<< parameters.footer >>\"
+        }")
+        <</ parameters.parameters.footer >>
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         {
@@ -137,6 +157,7 @@ steps:
         	}")
         done
         <</ parameters.button_links >>
+        echo $attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -133,7 +133,7 @@ steps:
         }')
         <</ parameters.dashboard_link >>
         <<# parameters.button_links >>
-        for link in << parameters.lighthouse_ph_results_link >>; do
+        for link in << parameters.button_links >>; do
         	name="${link##*/}"
         	name="${name%*.html}"
         	attachments_json=$(echo $attachments_json | jq '.[].actions[.[].actions | length] |= . +

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -98,12 +98,7 @@ steps:
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
-#          \"author_name\": \"$AUTHOR_NAME\",
-#          \"author_link\": \"$AUTHOR_LINK\",
           \"title\": \"$TITLE\",
-#          \"title_link\": \"$TITLE_LINK\",
-#          \"footer\": \"$FOOTER\",
-#          \"ts\": \"$TS\",
           \"fields\": [],
           \"actions\": [],
           \"color\": \"$COLOR\"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -187,7 +187,7 @@ steps:
             <<# parameters.channel >>
             -d "channel=<< parameters.channel >>"
             <</ parameters.channel >>
-            -d "attachments=["$encoded_attachments_json"]"
+            -d "attachments="$encoded_attachments_json"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -25,12 +25,12 @@ parameters:
   author_name:
     description: Optional author name
     type: string
-    default: "asdf"
+    default: ""
 
   author_link:
     description: Optional author link
     type: string
-    default: "asdf"
+    default: ""
 
   title:
     description: Optional title
@@ -45,12 +45,12 @@ parameters:
   footer:
     description: Optional footer
     type: string
-    default: "asdf"
+    default: ""
 
   ts:
     description: Optional timestamp
     type: string
-    default: "asdf"
+    default: ""
 
   include_project_field:
     description: Whether or not to include the Project field in the message
@@ -108,6 +108,12 @@ steps:
           \"author_link\": \"<< parameters.author_link >>\"
          }")
         <</ parameters.author_link >>
+        <<# parameters.title_link >>
+        attachments_json=$(echo $attachments_json | jq ".[] +=
+        {
+          \"title_link\": \"<< parameters.title_link >>\"
+        }")
+        <</ parameters.title_link >>
         <<# parameters.ts >>
         attachments_json=$(echo $attachments_json | jq ".[] +=
         {
@@ -157,7 +163,6 @@ steps:
         	}")
         done
         <</ parameters.button_links >>
-        echo $attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -87,14 +87,14 @@ steps:
       shell: /bin/bash
       command: |
         # set up attachments json
-        MESSAGE="\"<< parameters.message >>\""
-        AUTHOR_NAME="\"<< parameters.author_name >>\""
-        AUTHOR_LINK="\"<< parameters.author_link >>\""
-        TITLE="\"<< parameters.title >>\""
-        TITLE_LINK="\"<< parameters.title_link >>\""
-        FOOTER="\"<< parameters.footer >>\""
-        TS="\"<< parameters.ts >>\""
-        COLOR="\"<< parameters.color >>\""
+        MESSAGE=""<< parameters.message >>""
+        AUTHOR_NAME=""<< parameters.author_name >>""
+        AUTHOR_LINK=""<< parameters.author_link >>""
+        TITLE=""<< parameters.title >>""
+        TITLE_LINK=""<< parameters.title_link >>""
+        FOOTER=""<< parameters.footer >>""
+        TS=""<< parameters.ts >>""
+        COLOR=""<< parameters.color >>""
         attachments_json="[{
           \"fallback\": \"$MESSAGE - $CIRCLE_BUILD_URL\",
           \"text\": \"$MESSAGE $SLACK_MENTIONS\",
@@ -133,7 +133,7 @@ steps:
         }")
         <</ parameters.include_visit_job_action >>
         <<# parameters.button_links >>
-        BUTTON_LINKS="\"<< parameters.button_links >>\""
+        BUTTON_LINKS=""<< parameters.button_links >>""
         for link in $BUTTON_LINKS; do
         	name="${link##*/}"
         	name="${name%*.html}"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -101,7 +101,7 @@ steps:
           \"actions\": [], \
           \"color\": \"<< parameters.color >>\" \
         } \
-        ] \"
+        ] "
         <<# parameters.include_project_field >>
         attachments_json=$(echo $attachments_json | jq ".[].fields[.[].fields | length] |= . +
         { \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -137,26 +137,6 @@ steps:
         	}")
         done
         <</ parameters.button_links >>
-        function rawurlencode {
-          local string="${1}"
-          local strlen=${#string}
-          local encoded=""
-          local pos c o
-
-          for (( pos=0 ; pos<strlen ; pos++ )); do
-             c=${string:${pos}:1}
-             case "$c" in
-                [-_.~a-zA-Z0-9] ) o="${c}" ;;
-                * )               printf -v o '%%%02x' "'$c"
-             esac
-             encoded+="${o}"
-          done
-          echo "${encoded}"    # You can either set a return variable (FASTER)
-          REPLY="${encoded}"   #+or echo the result (EASIER)... or both... :p
-        }
-        encoded_attachments_json=$(rawurlencode "$attachments_json")
-        echo $attachments_json
-        echo $encoded_attachments_json
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"
@@ -187,7 +167,7 @@ steps:
             <<# parameters.channel >>
             -d "channel=<< parameters.channel >>"
             <</ parameters.channel >>
-            -d "attachments=$encoded_attachments_json"
+            -d "attachments=$attachments_json"
           )
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -165,17 +165,15 @@ steps:
                       \"type\": \"button\", \
                       \"text\": \"Dashboard\", \
                       \"url\": \"<< parameters.dashboard_link >>\" \
-                    } \
+                    }, \
                     <</ parameters.dashboard_link >>
-                  ], \
                     <<# parameters.lighthouse_bookings_results_link >>
                     { \
                       \"type\": \"button\", \
                       \"text\": \"Lighthouse Bookings\", \
                       \"url\": \"<< parameters.lighthouse_bookings_results_link >>\" \
-                    } \
+                    }, \
                     <</ parameters.lighthouse_bookings_results_link >>
-                  ], \
                     <<# parameters.lighthouse_ph_results_link >>
                     { \
                       \"type\": \"button\", \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -72,6 +72,17 @@ parameters:
     type: string
     default: ""
 
+  lighthouse_bookings_results_link:
+    description: The URL to the dashboard
+    type: string
+    default: ""
+
+  lighthouse_ph_results_link:
+    description: The URL to the dashboard
+    type: string
+    default: ""
+
+
 steps:
   - run:
       name: Provide error if non-bash shell
@@ -156,6 +167,22 @@ steps:
                       \"url\": \"<< parameters.dashboard_link >>\" \
                     } \
                     <</ parameters.dashboard_link >>
+                  ], \
+                    <<# parameters.lighthouse_bookings_results_link >>
+                    { \
+                      \"type\": \"button\", \
+                      \"text\": \"Lighthouse Bookings\", \
+                      \"url\": \"<< parameters.lighthouse_bookings_results_link >>\" \
+                    } \
+                    <</ parameters.lighthouse_bookings_results_link >>
+                  ], \
+                    <<# parameters.lighthouse_ph_results_link >>
+                    { \
+                      \"type\": \"button\", \
+                      \"text\": \"Lighthouse PH\", \
+                      \"url\": \"<< parameters.lighthouse_ph_results_link >>\" \
+                    } \
+                    <</ parameters.lighthouse_ph_results_link >>
                   ], \
                   \"color\": \"<< parameters.color >>\" \
                 } \

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -68,7 +68,7 @@ parameters:
     default: true
 
   lighthouse_button_links:
-    description: The URL to the dashboard
+    description: A string (json formatted) with the test names and results links
     type: string
     default: ""
 
@@ -138,7 +138,7 @@ steps:
                             <</ parameters.dashboard_link >>
                             <<# parameters.lighthouse_button_links >>
                             "
-        for row in $(echo "${sample}" | jq -c '.[]'); do
+        for row in $(echo "<< parameters.lighthouse_button_links >>" | jq -c '.[]'); do
             _jq() {
              echo ${row} | jq -r ${1}
             }

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -67,17 +67,7 @@ parameters:
     type: boolean
     default: true
 
-  dashboard_link:
-    description: The URL to the dashboard
-    type: string
-    default: ""
-
-  lighthouse_bookings_results_link:
-    description: The URL to the dashboard
-    type: string
-    default: ""
-
-  lighthouse_ph_results_link:
+  lighthouse_button_links:
     description: The URL to the dashboard
     type: string
     default: ""
@@ -96,6 +86,75 @@ steps:
       name: Slack Notification
       shell: /bin/bash
       command: |
+        # set up potential lighthouse test results
+        curl_arg_1="            -X POST
+                    -H 'Content-Type: application/x-www-form-urlencoded'
+                    -H 'Cache-Control: no-cache'
+                    -d \"token=\${SLACK_OAUTH_TOKEN}\"
+                    -d 'as_user=true'
+                    <<# parameters.channel >>
+                    -d \"channel=<< parameters.channel >>\"
+                    <</ parameters.channel >>
+                    -d \"attachments=[ \\
+                        { \\
+                          \\\"fallback\\\": \\\"<< parameters.message >> - \$CIRCLE_BUILD_URL\\\", \\
+                          \\\"text\\\": \\\"<< parameters.message >> \$SLACK_MENTIONS\\\", \\
+                          \\\"author_name\\\": \\\"<< parameters.author_name >>\\\", \\
+                          \\\"author_link\\\": \\\"<< parameters.author_link >>\\\", \\
+                          \\\"title\\\": \\\"<< parameters.title >>\\\", \\
+                          \\\"title_link\\\": \\\"<< parameters.title_link >>\\\", \\
+                          \\\"footer\\\": \\\"<< parameters.footer >>\\\", \\
+                          \\\"ts\\\": \\\"<< parameters.ts >>\\\", \\
+                          \\\"fields\\\": [ \\
+                            <<# parameters.include_project_field >>
+                            { \\
+                              \\\"title\\\": \\\"Project\\\", \\
+                              \\\"value\\\": \\\"\$CIRCLE_PROJECT_REPONAME\\\", \\
+                              \\\"short\\\": true \\
+                            }, \\
+                            <</ parameters.include_project_field >>
+                            <<# parameters.include_job_number_field >>
+                            { \\
+                              \\\"title\\\": \\\"Job Number\\\", \\
+                              \\\"value\\\": \\\"\$CIRCLE_BUILD_NUM\\\", \\
+                              \\\"short\\\": true \\
+                            } \\
+                            <</ parameters.include_job_number_field >>
+                          ], \\
+                          \\\"actions\\\": [ \\
+                            <<# parameters.include_visit_job_action >>
+                            { \\
+                              \\\"type\\\": \\\"button\\\", \\
+                              \\\"text\\\": \\\"Visit Job\\\", \\
+                              \\\"url\\\": \\\"\$CIRCLE_BUILD_URL\\\" \\
+                            }, \\
+                            <</ parameters.include_visit_job_action >>
+                            <</ parameters.dashboard_link >>
+                            { \\
+                              \\\"type\\\": \\\"button\\\", \\
+                              \\\"text\\\": \\\"Dashboard\\\", \\
+                              \\\"url\\\": \\\"<< parameters.dashboard_link >>\\\" \\
+                            }, \\
+                            <</ parameters.dashboard_link >>
+                            <<# parameters.lighthouse_button_links >>
+                            "
+        for row in $(echo "${sample}" | jq -c '.[]'); do
+            _jq() {
+             echo ${row} | jq -r ${1}
+            }
+        	curl_arg_2="$curlArg2{ \\
+                             \\\"type\\\": \\\"button\\\", \\
+                             \\\"text\\\": \\\"$(_jq '.name')\\\", \\
+                             \\\"url\\\": \\\"$(_jq '.url')\\\" \\
+                            }, \\
+                            "
+        done
+        curl_arg_3="<</ parameters.lighthouse_button_links >>
+                          ], \\
+                          \\\"color\\\": \\\"<< parameters.color >>\\\" \\
+                        } \\
+                      ]\""
+        curl_args=$curl_arg_1$curl_arg_2$curl_arg_3
         # Provide error if no token is set and error. Otherwise continue
         if [[ -z "$SLACK_OAUTH_TOKEN" ]]; then
           echo "NO SLACK_OAUTH_TOKEN SET"
@@ -117,74 +176,6 @@ steps:
               fi
             done
           fi
-          CURL_ARGS=(
-            -X POST
-            -H 'Content-Type: application/x-www-form-urlencoded'
-            -H 'Cache-Control: no-cache'
-            -d "token=${SLACK_OAUTH_TOKEN}"
-            -d 'as_user=true'
-            <<# parameters.channel >>
-            -d "channel=<< parameters.channel >>"
-            <</ parameters.channel >>
-            -d "attachments=[ \
-                { \
-                  \"fallback\": \"<< parameters.message >> - $CIRCLE_BUILD_URL\", \
-                  \"text\": \"<< parameters.message >> $SLACK_MENTIONS\", \
-                  \"author_name\": \"<< parameters.author_name >>\", \
-                  \"author_link\": \"<< parameters.author_link >>\", \
-                  \"title\": \"<< parameters.title >>\", \
-                  \"title_link\": \"<< parameters.title_link >>\", \
-                  \"footer\": \"<< parameters.footer >>\", \
-                  \"ts\": \"<< parameters.ts >>\", \
-                  \"fields\": [ \
-                    <<# parameters.include_project_field >>
-                    { \
-                      \"title\": \"Project\", \
-                      \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
-                      \"short\": true \
-                    }, \
-                    <</ parameters.include_project_field >>
-                    <<# parameters.include_job_number_field >>
-                    { \
-                      \"title\": \"Job Number\", \
-                      \"value\": \"$CIRCLE_BUILD_NUM\", \
-                      \"short\": true \
-                    } \
-                    <</ parameters.include_job_number_field >>
-                  ], \
-                  \"actions\": [ \
-                    <<# parameters.include_visit_job_action >>
-                    { \
-                      \"type\": \"button\", \
-                      \"text\": \"Visit Job\", \
-                      \"url\": \"$CIRCLE_BUILD_URL\" \
-                    }, \
-                    <</ parameters.include_visit_job_action >>
-                    <<# parameters.dashboard_link >>
-                    { \
-                      \"type\": \"button\", \
-                      \"text\": \"Dashboard\", \
-                      \"url\": \"<< parameters.dashboard_link >>\" \
-                    }, \
-                    <</ parameters.dashboard_link >>
-                    <<# parameters.lighthouse_bookings_results_link >>
-                    { \
-                      \"type\": \"button\", \
-                      \"text\": \"Lighthouse Bookings\", \
-                      \"url\": \"<< parameters.lighthouse_bookings_results_link >>\" \
-                    }, \
-                    <</ parameters.lighthouse_bookings_results_link >>
-                    <<# parameters.lighthouse_ph_results_link >>
-                    { \
-                      \"type\": \"button\", \
-                      \"text\": \"Lighthouse PH\", \
-                      \"url\": \"<< parameters.lighthouse_ph_results_link >>\" \
-                    } \
-                    <</ parameters.lighthouse_ph_results_link >>
-                  ], \
-                  \"color\": \"<< parameters.color >>\" \
-                } \
-              ]"
-          )
+          CURL_ARGS=("$curl_args")
           curl "${CURL_ARGS[@]}" "https://slack.com/api/chat.postMessage"
         fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Over time we will likely be running a handful of different Lighthouse tests and wanted to be able to have slack notifications reflect the results.


<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
This change allows us to dynamically generate button links to Lighthouse test results from a json.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
